### PR TITLE
Link component for the shared navigation

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -20,6 +20,14 @@ export namespace Components {
         "cardTitle": string;
         "color": string;
     }
+    interface SusePlLink {
+        /**
+          * The image path for the icon when the link type is `topmenu`
+         */
+        "icon": string;
+        "type": 'normal' | 'title' | 'topmenu';
+        "url": string;
+    }
     interface SusePlNavSection {
         "sectionTitle": string;
     }
@@ -52,6 +60,12 @@ declare global {
         prototype: HTMLSusePlHorizontalCardElement;
         new (): HTMLSusePlHorizontalCardElement;
     };
+    interface HTMLSusePlLinkElement extends Components.SusePlLink, HTMLStencilElement {
+    }
+    var HTMLSusePlLinkElement: {
+        prototype: HTMLSusePlLinkElement;
+        new (): HTMLSusePlLinkElement;
+    };
     interface HTMLSusePlNavSectionElement extends Components.SusePlNavSection, HTMLStencilElement {
     }
     var HTMLSusePlNavSectionElement: {
@@ -69,6 +83,7 @@ declare global {
         "suse-pl-content-area": HTMLSusePlContentAreaElement;
         "suse-pl-header": HTMLSusePlHeaderElement;
         "suse-pl-horizontal-card": HTMLSusePlHorizontalCardElement;
+        "suse-pl-link": HTMLSusePlLinkElement;
         "suse-pl-nav-section": HTMLSusePlNavSectionElement;
         "suse-pl-sidebar": HTMLSusePlSidebarElement;
     }
@@ -88,6 +103,14 @@ declare namespace LocalJSX {
         "cardTitle"?: string;
         "color"?: string;
     }
+    interface SusePlLink {
+        /**
+          * The image path for the icon when the link type is `topmenu`
+         */
+        "icon"?: string;
+        "type"?: 'normal' | 'title' | 'topmenu';
+        "url"?: string;
+    }
     interface SusePlNavSection {
         "sectionTitle"?: string;
     }
@@ -99,6 +122,7 @@ declare namespace LocalJSX {
         "suse-pl-content-area": SusePlContentArea;
         "suse-pl-header": SusePlHeader;
         "suse-pl-horizontal-card": SusePlHorizontalCard;
+        "suse-pl-link": SusePlLink;
         "suse-pl-nav-section": SusePlNavSection;
         "suse-pl-sidebar": SusePlSidebar;
     }
@@ -111,6 +135,7 @@ declare module "@stencil/core" {
             "suse-pl-content-area": LocalJSX.SusePlContentArea & JSXBase.HTMLAttributes<HTMLSusePlContentAreaElement>;
             "suse-pl-header": LocalJSX.SusePlHeader & JSXBase.HTMLAttributes<HTMLSusePlHeaderElement>;
             "suse-pl-horizontal-card": LocalJSX.SusePlHorizontalCard & JSXBase.HTMLAttributes<HTMLSusePlHorizontalCardElement>;
+            "suse-pl-link": LocalJSX.SusePlLink & JSXBase.HTMLAttributes<HTMLSusePlLinkElement>;
             "suse-pl-nav-section": LocalJSX.SusePlNavSection & JSXBase.HTMLAttributes<HTMLSusePlNavSectionElement>;
             "suse-pl-sidebar": LocalJSX.SusePlSidebar & JSXBase.HTMLAttributes<HTMLSusePlSidebarElement>;
         }

--- a/src/components/suse-pl-link/readme.md
+++ b/src/components/suse-pl-link/readme.md
@@ -1,0 +1,19 @@
+# suse-pl-link
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property | Attribute | Description                                                 | Type                               | Default     |
+| -------- | --------- | ----------------------------------------------------------- | ---------------------------------- | ----------- |
+| `icon`   | `icon`    | The image path for the icon when the link type is `topmenu` | `string`                           | `undefined` |
+| `type`   | `type`    |                                                             | `"normal" \| "title" \| "topmenu"` | `'normal'`  |
+| `url`    | `url`     |                                                             | `string`                           | `undefined` |
+
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/components/suse-pl-link/suse-pl-link.css
+++ b/src/components/suse-pl-link/suse-pl-link.css
@@ -1,0 +1,45 @@
+:host {
+  display: block;
+  font-size: 16px;
+}
+
+.type-normal {
+  font-size: 1em;
+  font-weight: 500;
+  text-decoration: none;
+  color: var(--color-black);
+}
+
+.type-title {
+  font-size: 1.125em;
+  font-weight: 700;
+  text-decoration: none;
+  color: var(--color-white);
+
+  &:hover {
+    color: var(--color-jungle)
+  }
+}
+
+.type-topmenu {
+  font-size: 0.75em;
+  font-weight: 400;
+  text-decoration: none;
+  color: var(--color-white);
+
+  &:hover {
+    color: var(--color-jungle)
+  }
+}
+
+img {
+  max-width: 1em;
+  max-height: 1em;
+  margin-right: 5px;
+}
+
+div {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}

--- a/src/components/suse-pl-link/suse-pl-link.tsx
+++ b/src/components/suse-pl-link/suse-pl-link.tsx
@@ -1,0 +1,38 @@
+import { Component, Host, h, Prop } from '@stencil/core';
+
+@Component({
+  tag: 'suse-pl-link',
+  styleUrl: 'suse-pl-link.css',
+  shadow: true,
+  assetsDirs: ['assets']
+})
+export class SusePlLink {
+  @Prop() type: 'normal' | 'title' | 'topmenu' = 'normal';
+  @Prop() url: string;
+
+  /**
+   *  The image path for the icon when the link type is `topmenu`
+   */
+  @Prop() icon: string;
+
+  render() {
+    const ClassMap = {
+      "type-normal": this.type === "normal",
+      "type-title": this.type === "title",
+      "type-topmenu": this.type === "topmenu",
+    }
+
+    return (
+      <Host>
+        <div>
+          {this.type == 'topmenu' && this.icon &&
+            <img src={this.icon} alt="icon" class="icon" />
+          }
+          <a href={this.url} class={ClassMap}>
+            <slot></slot>
+          </a>
+        </div>
+      </Host>
+    );
+  }
+}

--- a/src/components/suse-pl-link/test/suse-pl-link.e2e.ts
+++ b/src/components/suse-pl-link/test/suse-pl-link.e2e.ts
@@ -1,0 +1,11 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+describe('suse-pl-link', () => {
+  it('renders', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<suse-pl-link></suse-pl-link>');
+
+    const element = await page.find('suse-pl-link');
+    expect(element).toHaveClass('hydrated');
+  });
+});

--- a/src/components/suse-pl-link/test/suse-pl-link.spec.tsx
+++ b/src/components/suse-pl-link/test/suse-pl-link.spec.tsx
@@ -1,0 +1,18 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { SusePlLink } from '../suse-pl-link';
+
+describe('suse-pl-link', () => {
+  it('renders', async () => {
+    const page = await newSpecPage({
+      components: [SusePlLink],
+      html: `<suse-pl-link></suse-pl-link>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <suse-pl-link>
+        <mock:shadow-root>
+          <slot></slot>
+        </mock:shadow-root>
+      </suse-pl-link>
+    `);
+  });
+});

--- a/src/index.html
+++ b/src/index.html
@@ -1,140 +1,132 @@
 <!DOCTYPE html>
 <html dir="ltr" lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
+    <title>Stencil Component Starter</title>
 
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
-  <title>Stencil Component Starter</title>
-
-  <script type="module" src="/build/suse-pl.esm.js"></script>
-  <script nomodule src="/build/suse-pl.js"></script>
-  <link rel="stylesheet" href="/build/suse-pl.css" />
-  <style>
-    /*
+    <script type="module" src="/build/suse-pl.esm.js"></script>
+    <script nomodule src="/build/suse-pl.js"></script>
+    <link rel="stylesheet" href="/build/suse-pl.css" />
+    <style>
+      /*
       SUSE Pattern Library Reset
       */
 
-    /* EASY BOX MODEL */
-    *,
-    ::before,
-    ::after {
-      box-sizing: border-box;
-    }
+      /* EASY BOX MODEL */
+      *, ::before, ::after {
+        box-sizing: border-box;
+      }
+      /* NO MARGIN BY DEFAULT */
+      * {
+        margin: 0;
+      }
+      /* FONT FIXES */
+      body {
+        font-family: sans-serif;
+        line-height: 1.5;
+        -webkit-font-smoothing: antialiased;
+      }
+      /* MEDIA */
+      :is(img, picture, video, canvas, svg) {
+        display: block;
+        max-width: 100%;
+      }
+      /* FIX FORM FONTS */
+      :is(input, button, textarea, select) {
+        font: inherit;
+      }
+      /* NO TEXT OVERFLOW */
+      :is(p, h1, h2, h3, h4, h5, h6) {
+        overflow-wrap: break-word;
+      }
+    </style>
+    <style>
+      body {
+        background-color: var(--color-fog-8);
+      }
 
-    /* NO MARGIN BY DEFAULT */
-    * {
-      margin: 0;
-    }
+      body.suse-pl {
+        background-color: var(--color-jungle-8);
+      }
+    </style>
+  </head>
+  <body class="suse-pl">
+    <suse-pl-header page-title="Pattern Library" logo-src="https://www.suse.com/assets/img/suse-white-logo-green.svg">
+    </suse-pl-header>
+    <suse-pl-sidebar>
+      <suse-pl-nav-section section-title="About">
+        <li class="disabled">
+          Getting Started</a>
+        </li>
+        <li class="disabled">
+          Terms of Use
+        </li>
+      </suse-pl-nav-section>
+      <suse-pl-nav-section section-title="Style Guide">
+        <li class="disabled">Color Palette</li>
+        <li class="disabled">Typography</li>
+        <li class="disabled">Logos</li>
+        <li class="disabled">Headings</li>
+      </suse-pl-nav-section>
+      <suse-pl-nav-section section-title="Accessiblity">
+        <li class="disabled">Overview</li>
+        <li class="disabled">Developer checklist</li>
+        <li class="disabled">Keyboard Patterns</li>
+        <li class="disabled">Color Contrast</li>
+        <li class="disabled">Heirarchy</li>
+      </suse-pl-nav-section>
+      <suse-pl-nav-section section-title="Icons">
+        <li class="disabled">Spot Icons</li>
+        <li class="disabled">Actions/General</li>
+        <li class="disabled">Admonitions</li>
+      </suse-pl-nav-section>
+      <suse-pl-nav-section section-title="Components">
+        <li class="disabled">Header</li>
+        <li class="disabled">Sidebar</li>
+        <li class="active">
+          <a href="#" class="active">Buttons</a>
+        </li>
+        <li class="disabled">Tables</li>
+        <li class="disabled">Text Box</li>
+        <li class="disabled">Logos</li>
+        <li class="disabled">Errors/Warnings</li>
+      </suse-pl-nav-section>
+    </suse-pl-sidebar>
+    <suse-pl-content-area>
+      <h1>Buttons</h1>
+      <h2>Primary Buttons</h2>
+      <p>
+        <suse-pl-button class="primary persimmon">Submit</suse-pl-button>
+        <suse-pl-button class="primary pine">Save</suse-pl-button>
+        <suse-pl-button class="primary waterhole">Download</suse-pl-button>
+      </p>
+      <h2>Secondary Buttons</h2>
+      <p>
+        <suse-pl-button class="secondary persimmon">Submit</suse-pl-button>
+        <suse-pl-button class="secondary pine">Save</suse-pl-button>
+        <suse-pl-button class="secondary waterhole">Download</suse-pl-button>
+      </p>
+      <h2>Tertiary Buttons</h2>
+      <p>
+        <suse-pl-button class="tertiary persimmon">Submit</suse-pl-button>
+        <suse-pl-button class="tertiary pine">Save</suse-pl-button>
+        <suse-pl-button class="tertiary waterhole">Download</suse-pl-button>
+      </p>
+      <h2>Disabled Buttons</h2>
+      <p>
+        <suse-pl-button class="primary persimmon disabled">Submit</suse-pl-button>
+        <suse-pl-button class="secondary pine disabled">Save</suse-pl-button>
+        <suse-pl-button class="tertiary waterhole disabled">Download</suse-pl-button>
+      </p>
+      <h2>Danger/Warning</h2>
+      <p>
+        <suse-pl-button class="danger">Delete</suse-pl-button>
+        <suse-pl-button class="warning">Caution</suse-pl-button>
+      </p>
 
-    /* FONT FIXES */
-    body {
-      font-family: sans-serif;
-      line-height: 1.5;
-      -webkit-font-smoothing: antialiased;
-    }
 
-    /* MEDIA */
-    :is(img, picture, video, canvas, svg) {
-      display: block;
-      max-width: 100%;
-    }
-
-    /* FIX FORM FONTS */
-    :is(input, button, textarea, select) {
-      font: inherit;
-    }
-
-    /* NO TEXT OVERFLOW */
-    :is(p, h1, h2, h3, h4, h5, h6) {
-      overflow-wrap: break-word;
-    }
-  </style>
-  <style>
-    body {
-      background-color: var(--color-fog-8);
-    }
-
-    body.suse-pl {
-      background-color: var(--color-jungle-8);
-    }
-  </style>
-</head>
-
-<body class="suse-pl">
-  <suse-pl-header page-title="Pattern Library" logo-src="https://www.suse.com/assets/img/suse-white-logo-green.svg">
-  </suse-pl-header>
-  <suse-pl-sidebar>
-    <suse-pl-nav-section section-title="About">
-      <li class="disabled">
-        Getting Started</a>
-      </li>
-      <li class="disabled">
-        Terms of Use
-      </li>
-    </suse-pl-nav-section>
-    <suse-pl-nav-section section-title="Style Guide">
-      <li class="disabled">Color Palette</li>
-      <li class="disabled">Typography</li>
-      <li class="disabled">Logos</li>
-      <li class="disabled">Headings</li>
-    </suse-pl-nav-section>
-    <suse-pl-nav-section section-title="Accessiblity">
-      <li class="disabled">Overview</li>
-      <li class="disabled">Developer checklist</li>
-      <li class="disabled">Keyboard Patterns</li>
-      <li class="disabled">Color Contrast</li>
-      <li class="disabled">Heirarchy</li>
-    </suse-pl-nav-section>
-    <suse-pl-nav-section section-title="Icons">
-      <li class="disabled">Spot Icons</li>
-      <li class="disabled">Actions/General</li>
-      <li class="disabled">Admonitions</li>
-    </suse-pl-nav-section>
-    <suse-pl-nav-section section-title="Components">
-      <li class="disabled">Header</li>
-      <li class="disabled">Sidebar</li>
-      <li class="active">
-        <a href="#" class="active">Buttons</a>
-      </li>
-      <li class="disabled">Tables</li>
-      <li class="disabled">Text Box</li>
-      <li class="disabled">Logos</li>
-      <li class="disabled">Errors/Warnings</li>
-    </suse-pl-nav-section>
-  </suse-pl-sidebar>
-  <suse-pl-content-area>
-    <h1>Buttons</h1>
-    <h2>Primary Buttons</h2>
-    <p>
-      <suse-pl-button class="primary persimmon">Submit</suse-pl-button>
-      <suse-pl-button class="primary pine">Save</suse-pl-button>
-      <suse-pl-button class="primary waterhole">Download</suse-pl-button>
-    </p>
-    <h2>Secondary Buttons</h2>
-    <p>
-      <suse-pl-button class="secondary persimmon">Submit</suse-pl-button>
-      <suse-pl-button class="secondary pine">Save</suse-pl-button>
-      <suse-pl-button class="secondary waterhole">Download</suse-pl-button>
-    </p>
-    <h2>Tertiary Buttons</h2>
-    <p>
-      <suse-pl-button class="tertiary persimmon">Submit</suse-pl-button>
-      <suse-pl-button class="tertiary pine">Save</suse-pl-button>
-      <suse-pl-button class="tertiary waterhole">Download</suse-pl-button>
-    </p>
-    <h2>Disabled Buttons</h2>
-    <p>
-      <suse-pl-button class="primary persimmon disabled">Submit</suse-pl-button>
-      <suse-pl-button class="secondary pine disabled">Save</suse-pl-button>
-      <suse-pl-button class="tertiary waterhole disabled">Download</suse-pl-button>
-    </p>
-    <h2>Danger/Warning</h2>
-    <p>
-      <suse-pl-button class="danger">Delete</suse-pl-button>
-      <suse-pl-button class="warning">Caution</suse-pl-button>
-    </p>
-
-    <h1>Links</h1>
+    <h1 style="margin-top: 30px;">Links</h1>
     <p>
       <suse-pl-link url="https://www.suse.com" type="normal">Menu item link</suse-pl-link>
     <div style="background-color:var(--color-pine); font-size: 106px;">
@@ -145,7 +137,7 @@
       </suse-pl-link>
     </div>
     </p>
-  </suse-pl-content-area>
-</body>
 
+    </suse-pl-content-area>
+  </body>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -1,129 +1,151 @@
 <!DOCTYPE html>
 <html dir="ltr" lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
-    <title>Stencil Component Starter</title>
 
-    <script type="module" src="/build/suse-pl.esm.js"></script>
-    <script nomodule src="/build/suse-pl.js"></script>
-    <link rel="stylesheet" href="/build/suse-pl.css" />
-    <style>
-      /*
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
+  <title>Stencil Component Starter</title>
+
+  <script type="module" src="/build/suse-pl.esm.js"></script>
+  <script nomodule src="/build/suse-pl.js"></script>
+  <link rel="stylesheet" href="/build/suse-pl.css" />
+  <style>
+    /*
       SUSE Pattern Library Reset
       */
 
-      /* EASY BOX MODEL */
-      *, ::before, ::after {
-        box-sizing: border-box;
-      }
-      /* NO MARGIN BY DEFAULT */
-      * {
-        margin: 0;
-      }
-      /* FONT FIXES */
-      body {
-        font-family: sans-serif;
-        line-height: 1.5;
-        -webkit-font-smoothing: antialiased;
-      }
-      /* MEDIA */
-      :is(img, picture, video, canvas, svg) {
-        display: block;
-        max-width: 100%;
-      }
-      /* FIX FORM FONTS */
-      :is(input, button, textarea, select) {
-        font: inherit;
-      }
-      /* NO TEXT OVERFLOW */
-      :is(p, h1, h2, h3, h4, h5, h6) {
-        overflow-wrap: break-word;
-      }
-    </style>
-    <style>
-      body {
-        background-color: var(--color-fog-8);
-      }
+    /* EASY BOX MODEL */
+    *,
+    ::before,
+    ::after {
+      box-sizing: border-box;
+    }
 
-      body.suse-pl {
-        background-color: var(--color-jungle-8);
-      }
-    </style>
-  </head>
-  <body class="suse-pl">
-    <suse-pl-header page-title="Pattern Library" logo-src="https://www.suse.com/assets/img/suse-white-logo-green.svg">
-    </suse-pl-header>
-    <suse-pl-sidebar>
-      <suse-pl-nav-section section-title="About">
-        <li class="disabled">
-          Getting Started</a>
-        </li>
-        <li class="disabled">
-          Terms of Use
-        </li>
-      </suse-pl-nav-section>
-      <suse-pl-nav-section section-title="Style Guide">
-        <li class="disabled">Color Palette</li>
-        <li class="disabled">Typography</li>
-        <li class="disabled">Logos</li>
-        <li class="disabled">Headings</li>
-      </suse-pl-nav-section>
-      <suse-pl-nav-section section-title="Accessiblity">
-        <li class="disabled">Overview</li>
-        <li class="disabled">Developer checklist</li>
-        <li class="disabled">Keyboard Patterns</li>
-        <li class="disabled">Color Contrast</li>
-        <li class="disabled">Heirarchy</li>
-      </suse-pl-nav-section>
-      <suse-pl-nav-section section-title="Icons">
-        <li class="disabled">Spot Icons</li>
-        <li class="disabled">Actions/General</li>
-        <li class="disabled">Admonitions</li>
-      </suse-pl-nav-section>
-      <suse-pl-nav-section section-title="Components">
-        <li class="disabled">Header</li>
-        <li class="disabled">Sidebar</li>
-        <li class="active">
-          <a href="#" class="active">Buttons</a>
-        </li>
-        <li class="disabled">Tables</li>
-        <li class="disabled">Text Box</li>
-        <li class="disabled">Logos</li>
-        <li class="disabled">Errors/Warnings</li>
-      </suse-pl-nav-section>
-    </suse-pl-sidebar>
-    <suse-pl-content-area>
-      <h1>Buttons</h1>
-      <h2>Primary Buttons</h2>
-      <p>
-        <suse-pl-button class="primary persimmon">Submit</suse-pl-button>
-        <suse-pl-button class="primary pine">Save</suse-pl-button>
-        <suse-pl-button class="primary waterhole">Download</suse-pl-button>
-      </p>
-      <h2>Secondary Buttons</h2>
-      <p>
-        <suse-pl-button class="secondary persimmon">Submit</suse-pl-button>
-        <suse-pl-button class="secondary pine">Save</suse-pl-button>
-        <suse-pl-button class="secondary waterhole">Download</suse-pl-button>
-      </p>
-      <h2>Tertiary Buttons</h2>
-      <p>
-        <suse-pl-button class="tertiary persimmon">Submit</suse-pl-button>
-        <suse-pl-button class="tertiary pine">Save</suse-pl-button>
-        <suse-pl-button class="tertiary waterhole">Download</suse-pl-button>
-      </p>
-      <h2>Disabled Buttons</h2>
-      <p>
-        <suse-pl-button class="primary persimmon disabled">Submit</suse-pl-button>
-        <suse-pl-button class="secondary pine disabled">Save</suse-pl-button>
-        <suse-pl-button class="tertiary waterhole disabled">Download</suse-pl-button>
-      </p>
-      <h2>Danger/Warning</h2>
-      <p>
-        <suse-pl-button class="danger">Delete</suse-pl-button>
-        <suse-pl-button class="warning">Caution</suse-pl-button>
-      </p>
-    </suse-pl-content-area>
-  </body>
+    /* NO MARGIN BY DEFAULT */
+    * {
+      margin: 0;
+    }
+
+    /* FONT FIXES */
+    body {
+      font-family: sans-serif;
+      line-height: 1.5;
+      -webkit-font-smoothing: antialiased;
+    }
+
+    /* MEDIA */
+    :is(img, picture, video, canvas, svg) {
+      display: block;
+      max-width: 100%;
+    }
+
+    /* FIX FORM FONTS */
+    :is(input, button, textarea, select) {
+      font: inherit;
+    }
+
+    /* NO TEXT OVERFLOW */
+    :is(p, h1, h2, h3, h4, h5, h6) {
+      overflow-wrap: break-word;
+    }
+  </style>
+  <style>
+    body {
+      background-color: var(--color-fog-8);
+    }
+
+    body.suse-pl {
+      background-color: var(--color-jungle-8);
+    }
+  </style>
+</head>
+
+<body class="suse-pl">
+  <suse-pl-header page-title="Pattern Library" logo-src="https://www.suse.com/assets/img/suse-white-logo-green.svg">
+  </suse-pl-header>
+  <suse-pl-sidebar>
+    <suse-pl-nav-section section-title="About">
+      <li class="disabled">
+        Getting Started</a>
+      </li>
+      <li class="disabled">
+        Terms of Use
+      </li>
+    </suse-pl-nav-section>
+    <suse-pl-nav-section section-title="Style Guide">
+      <li class="disabled">Color Palette</li>
+      <li class="disabled">Typography</li>
+      <li class="disabled">Logos</li>
+      <li class="disabled">Headings</li>
+    </suse-pl-nav-section>
+    <suse-pl-nav-section section-title="Accessiblity">
+      <li class="disabled">Overview</li>
+      <li class="disabled">Developer checklist</li>
+      <li class="disabled">Keyboard Patterns</li>
+      <li class="disabled">Color Contrast</li>
+      <li class="disabled">Heirarchy</li>
+    </suse-pl-nav-section>
+    <suse-pl-nav-section section-title="Icons">
+      <li class="disabled">Spot Icons</li>
+      <li class="disabled">Actions/General</li>
+      <li class="disabled">Admonitions</li>
+    </suse-pl-nav-section>
+    <suse-pl-nav-section section-title="Components">
+      <li class="disabled">Header</li>
+      <li class="disabled">Sidebar</li>
+      <li class="active">
+        <a href="#" class="active">Buttons</a>
+      </li>
+      <li class="disabled">Tables</li>
+      <li class="disabled">Text Box</li>
+      <li class="disabled">Logos</li>
+      <li class="disabled">Errors/Warnings</li>
+    </suse-pl-nav-section>
+  </suse-pl-sidebar>
+  <suse-pl-content-area>
+    <h1>Buttons</h1>
+    <h2>Primary Buttons</h2>
+    <p>
+      <suse-pl-button class="primary persimmon">Submit</suse-pl-button>
+      <suse-pl-button class="primary pine">Save</suse-pl-button>
+      <suse-pl-button class="primary waterhole">Download</suse-pl-button>
+    </p>
+    <h2>Secondary Buttons</h2>
+    <p>
+      <suse-pl-button class="secondary persimmon">Submit</suse-pl-button>
+      <suse-pl-button class="secondary pine">Save</suse-pl-button>
+      <suse-pl-button class="secondary waterhole">Download</suse-pl-button>
+    </p>
+    <h2>Tertiary Buttons</h2>
+    <p>
+      <suse-pl-button class="tertiary persimmon">Submit</suse-pl-button>
+      <suse-pl-button class="tertiary pine">Save</suse-pl-button>
+      <suse-pl-button class="tertiary waterhole">Download</suse-pl-button>
+    </p>
+    <h2>Disabled Buttons</h2>
+    <p>
+      <suse-pl-button class="primary persimmon disabled">Submit</suse-pl-button>
+      <suse-pl-button class="secondary pine disabled">Save</suse-pl-button>
+      <suse-pl-button class="tertiary waterhole disabled">Download</suse-pl-button>
+    </p>
+    <h2>Danger/Warning</h2>
+    <p>
+      <suse-pl-button class="danger">Delete</suse-pl-button>
+      <suse-pl-button class="warning">Caution</suse-pl-button>
+    </p>
+
+    <h1>Links</h1>
+    <p>
+      <suse-pl-link url="https://www.suse.com" type="normal">Menu item link</suse-pl-link>
+    <div style="background-color:var(--color-pine); font-size: 106px;">
+      <suse-pl-link url=" https://www.suse.com" type="title">Subsite title</suse-pl-link>
+      <suse-pl-link url="https://www.suse.com" type="topmenu"
+        icon="https://cdn.bfldr.com/FQEVVFCB/at/m4sj8mv8wxrssrgvcs88mm/Run-SAP-Solutions-Persimmon-pos.svg?auto=webp&format=png">
+        Top menu link
+      </suse-pl-link>
+    </div>
+    </p>
+  </suse-pl-content-area>
+</body>
+
 </html>


### PR DESCRIPTION
This PR contains a link component which contains different `type` options that are styled to match the different types of link that are defined in the shared navigation mockup.

Related Jira ticket: https://jira.suse.com/browse/SCC-63

Mockup: https://ycjm36.axshare.com/?id=cdv8vx&p=navigation__scc_dark_example_&g=1